### PR TITLE
TECH-4973 - Add Cookie3 script (staging)

### DIFF
--- a/apps/webapp/src/index.html
+++ b/apps/webapp/src/index.html
@@ -9,6 +9,15 @@
     />
     <title>Sky | Get rewarded for saving, without giving up control</title>
 
+    <script
+      src="https://cdn.markfi.xyz/scripts/analytics/0.11.24/cookie3.analytics.min.js"
+      integrity="sha384-ihnQ09PGDbDPthGB3QoQ2Heg2RwQIDyWkHkqxMzq91RPeP8OmydAZbQLgAakAOfI"
+      crossOrigin="anonymous"
+      async="true"
+      strategy="lazyOnload"
+      site-id="%VITE_COOKIE3_SITE_ID%"
+    ></script>
+
     <!-- Pinned Sites  -->
     <meta name="application-name" content="Sky | Get rewarded for saving, without giving up control" />
     <meta name="msapplication-tooltip" content="Sky | Get rewarded for saving, without giving up control" />

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -28,6 +28,7 @@ export default ({ mode }: { mode: modeEnum }) => {
     default-src 'self';
     script-src 'self'
       'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+      https://cdn.markfi.xyz
       https://static.cloudflareinsights.com
       https://challenges.cloudflare.com;
     style-src 'self' 'unsafe-inline';


### PR DESCRIPTION
The env var `VITE_COOKIE3_SITE_ID` is already available to the app and the syntax for its replacement was taken from [here](https://vite.dev/guide/env-and-mode#html-constant-replacement).